### PR TITLE
misc dc8200 fixes

### DIFF
--- a/drivers/gpu/drm/verisilicon/vs_crtc.c
+++ b/drivers/gpu/drm/verisilicon/vs_crtc.c
@@ -389,6 +389,7 @@ struct vs_crtc *vs_crtc_create(struct drm_device *drm_dev,
                        VS_SINGLE_DC);
     }
 
+#if 0
     if (info->gamma_size) {
         ret = drm_mode_crtc_set_gamma_size(&crtc->base,
                            info->gamma_size);
@@ -398,6 +399,7 @@ struct vs_crtc *vs_crtc_create(struct drm_device *drm_dev,
         drm_crtc_enable_color_mgmt(&crtc->base, 0, false,
                        info->gamma_size);
     }
+#endif
 
     if (info->background) {
         crtc->bg_color = drm_property_create_range(drm_dev, 0,

--- a/drivers/gpu/drm/verisilicon/vs_gem.c
+++ b/drivers/gpu/drm/verisilicon/vs_gem.c
@@ -100,8 +100,7 @@ static int vs_gem_alloc_buf(struct vs_gem_object *vs_obj)
         return 0;
     }
 
-    vs_obj->dma_attrs = DMA_ATTR_WRITE_COMBINE
-               | DMA_ATTR_NO_KERNEL_MAPPING;
+    vs_obj->dma_attrs = DMA_ATTR_WRITE_COMBINE;
 
     if (!is_iommu_enabled(dev))
         vs_obj->dma_attrs |= DMA_ATTR_FORCE_CONTIGUOUS;


### PR DESCRIPTION
- Disable gamma LUT, which is not compatible with newer versions of Xorg.
- Fix FBCON cache issue by always mapping GEMs.