### PR TITLE
riscv: dts: thead: lpi4a: change fan PWM frequency

### DIFF
--- a/arch/riscv/boot/dts/thead/light-lpi4a-ref.dts
+++ b/arch/riscv/boot/dts/thead/light-lpi4a-ref.dts
@@ -194,7 +194,7 @@
 	fan: pwm-fan {
 		compatible = "pwm-fan";
 		#cooling-cells = <2>;
-		pwms = <&pwm 1 1000000 0>;
+		pwms = <&pwm 1 10000000 0>;
 		cooling-levels = <0 64 192 255>;
 	};
 


### PR DESCRIPTION
The fan PWM is originally running at 1kHz, which leads to some annoying noise.

Lower it to 100Hz now.