### PR TITLE
Input: joystick - fix Kconfig warning for JOYSTICK_ADC

### DIFF
--- a/drivers/input/joystick/Kconfig
+++ b/drivers/input/joystick/Kconfig
@@ -45,6 +45,7 @@ config JOYSTICK_A3D
 config JOYSTICK_ADC
 	tristate "Simple joystick connected over ADC"
 	depends on IIO
+	select IIO_BUFFER
 	select IIO_BUFFER_CB
 	help
 	  Say Y here if you have a simple joystick connected over ADC.


### PR DESCRIPTION
Fix:https://github.com/deepin-community/deepin-riscv-kernel/actions/runs/5437424634/jobs/9887970263
WARNING: unmet direct dependencies detected for IIO_BUFFER_CB
  Depends on [n]: IIO [=y] && IIO_BUFFER [=n]
  Selected by [m]:
  - JOYSTICK_ADC [=m] && !UML && INPUT [=y] && INPUT_JOYSTICK [=y] && IIO [=y]

WARNING: unmet direct dependencies detected for IIO_BUFFER_CB
  Depends on [n]: IIO [=y] && IIO_BUFFER [=n]
  Selected by [m]:
  - JOYSTICK_ADC [=m] && !UML && INPUT [=y] && INPUT_JOYSTICK [=y] && IIO [=y]
#
# configuration written to .config
#
  SYNC    include/config/auto.conf.cmd

WARNING: unmet direct dependencies detected for IIO_BUFFER_CB
  Depends on [n]: IIO [=y] && IIO_BUFFER [=n]
  Selected by [m]:
  - JOYSTICK_ADC [=m] && !UML && INPUT [=y] && INPUT_JOYSTICK [=y] && IIO [=y]

WARNING: unmet direct dependencies detected for IIO_BUFFER_CB
  Depends on [n]: IIO [=y] && IIO_BUFFER [=n]
  Selected by [m]:
  - JOYSTICK_ADC [=m] && !UML && INPUT [=y] && INPUT_JOYSTICK [=y] && IIO [=y]
[ Upstream commit 6100a19c4fcfe154dd32f8a8ef4e8c0b1f607c75 ]

Fix a Kconfig warning for JOYSTICK_ADC by also selecting IIO_BUFFER.

WARNING: unmet direct dependencies detected for IIO_BUFFER_CB
  Depends on [n]: IIO [=y] && IIO_BUFFER [=n]
  Selected by [y]:
  - JOYSTICK_ADC [=y] && INPUT [=y] && INPUT_JOYSTICK [=y] && IIO [=y]

Fixes: 2c2b364fddd5 ("Input: joystick - add ADC attached joystick driver.")
Reported-by: kernel test robot <lkp@intel.com>

Link: https://lore.kernel.org/r/20221104201238.31628-1-rdunlap@infradead.org