### PR TITLE
riscv: dts: thead: downclock SD card for LPi4A

### DIFF
--- a/arch/riscv/boot/dts/thead/light-lpi4a-ref.dts
+++ b/arch/riscv/boot/dts/thead/light-lpi4a-ref.dts
@@ -865,7 +865,7 @@
 };
 
 &sdhci0 {
-	max-frequency = <198000000>;
+	max-frequency = <100000000>;
 	bus-width = <4>;
 	pull_up;
 	wprtn_ignore;


### PR DESCRIPTION
It's reported that @198MHz some R/W error will happen.