### PR TITLE
drm/verisilicon: add format_mod_supported to plane (Fixes newer versions of Weston not starting)

### DIFF
--- a/drivers/gpu/drm/verisilicon/vs_plane.c
+++ b/drivers/gpu/drm/verisilicon/vs_plane.c
@@ -193,6 +193,27 @@ static int vs_plane_atomic_get_property(struct drm_plane *plane,
     return 0;
 }
 
+static bool vs_plane_format_mod_supported(struct drm_plane *plane,
+					  uint32_t format,
+					  uint64_t modifier)
+{
+	struct vs_plane *vs_plane = to_vs_plane(plane);
+	int i;
+
+	for(i = 0; i < vs_plane->info->num_modifiers; i++) {
+		if (vs_plane->info->modifiers[i] == modifier)
+			break;
+	}
+	if (i && i == vs_plane->info->num_modifiers)
+		return false;
+
+	for(i = 0; i < vs_plane->info->num_formats; i++) {
+		if (vs_plane->info->formats[i] == format)
+			return true;
+	}
+	return false;
+}
+
 const struct drm_plane_funcs vs_plane_funcs = {
     .update_plane       = drm_atomic_helper_update_plane,
     .disable_plane      = drm_atomic_helper_disable_plane,
@@ -202,6 +223,7 @@ const struct drm_plane_funcs vs_plane_funcs = {
     .atomic_destroy_state   = vs_plane_atomic_destroy_state,
     .atomic_set_property    = vs_plane_atomic_set_property,
     .atomic_get_property    = vs_plane_atomic_get_property,
+    .format_mod_supported   = vs_plane_format_mod_supported,
 };
 
 static unsigned char vs_get_plane_number(struct drm_framebuffer *fb)
@@ -299,6 +321,8 @@ struct vs_plane *vs_plane_create(struct drm_device *drm_dev,
     plane = kzalloc(sizeof(struct vs_plane), GFP_KERNEL);
     if (!plane)
         return NULL;
+
+    plane->info = info;
 
     ret = drm_universal_plane_init(drm_dev, &plane->base, possible_crtcs,
                 &vs_plane_funcs, info->formats,

--- a/drivers/gpu/drm/verisilicon/vs_plane.h
+++ b/drivers/gpu/drm/verisilicon/vs_plane.h
@@ -47,6 +47,7 @@ struct vs_plane {
     struct drm_plane base;
     u8 id;
     dma_addr_t dma_addr[MAX_NUM_PLANES];
+    struct vs_plane_info *info;
 
     struct drm_property *degamma_mode;
     struct drm_property *watermark_prop;


### PR DESCRIPTION
Otherwise IN_FORMATS blob is corrupted.