### PR TITLE
use register satp instead of sptbr

### DIFF
--- a/arch/riscv/mm/context.c
+++ b/arch/riscv/mm/context.c
@@ -98,7 +98,7 @@ void switch_mm(struct mm_struct *prev, struct mm_struct *next,
 			"sfence.vma t0, t0\n\t"
 			::: "memory", "t0");
 
-	csr_write(sptbr, virt_to_pfn(next->pgd) | SATP_MODE | asid);
+	csr_write(satp, virt_to_pfn(next->pgd) | SATP_MODE | asid);
 #endif
 
 	flush_icache_deferred(next);


### PR DESCRIPTION
This register was renamed in some revision of RISC-V.

Currently compilation with a recent toolchain errors with:

```
arch/riscv/mm/context.c: Assembler messages:
arch/riscv/mm/context.c:101: Error: unknown CSR `sptbr'
```